### PR TITLE
[token refresh] Compatibility with python “idan/oauthlib”

### DIFF
--- a/NXOAuth2Account+Private.h
+++ b/NXOAuth2Account+Private.h
@@ -14,6 +14,7 @@
 #import <OAuth2Client/NXOAuth2Account.h>
 
 @protocol NXApplication;
+@class NXOAuth2AccessToken;
 
 @interface NXOAuth2Account (Private)
 
@@ -26,5 +27,7 @@
 - (instancetype)initAccountWithAccessToken:(NXOAuth2AccessToken *)accessToken
                                accountType:(NSString *)accountType
                                application:(id<NXApplication>)app /*NS_DESIGNATED_INITIALIZER*/ NS_REQUIRES_SUPER;
+
+@property (nonatomic, strong) NXOAuth2AccessToken *accessToken;
 
 @end

--- a/Sources/OAuth2Client/NXOAuth2Account.m
+++ b/Sources/OAuth2Client/NXOAuth2Account.m
@@ -35,6 +35,7 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
 @interface NXOAuth2Account () <NXOAuth2ClientDelegate, NXOAuth2TrustDelegate>
 
 @property (nonatomic, readwrite) id<NXApplication> application;
+@property (nonatomic, strong) NXOAuth2AccessToken *accessToken;
 
 @end
 

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -499,7 +499,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     [self->_uiApplication openURL: preparedURL];
 }
 
-- (void)oauthClientDidGetAccessToken:(NXOAuth2Client *)client;
+- (void)oauthClientDidGetAccessToken:(NXOAuth2Client *)client
 {
     NSString *accountType;
     @synchronized (self.pendingOAuthClients) {
@@ -512,6 +512,31 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                                        application:self->_uiApplication];
 
     [self addAccount:account];
+}
+
+- (void)oauthClientDidRefreshAccessToken:(NXOAuth2Client *)client
+{
+    NXOAuth2Account* foundAccount = nil;
+
+    @synchronized (self.accountsDict)
+    {
+        for (NXOAuth2Account* account in self.accounts)
+        {
+            if (account.oauthClient == client)
+            {
+                foundAccount = account;
+                break;
+            }
+        }
+    }
+    
+    foundAccount.accessToken = client.accessToken;
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject: foundAccount
+                                                         forKey: NXOAuth2AccountStoreNewAccountUserInfoKey];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:NXOAuth2AccountStoreAccountsDidChangeNotification
+                                                        object:self
+                                                      userInfo:userInfo];
 }
 
 - (void)addAccount:(NXOAuth2Account *)account;


### PR DESCRIPTION
Library site : https://oauthlib.readthedocs.org/en/latest/

Fixed issues :

OAuth token refresh lacks "Authorization" header required by "idan/oauthlib"
OAuth token is not updated in account store after refresh
Client code is not notified about refresh events
